### PR TITLE
Add info about renaming of web directory to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To enable you an easy workflow, this repository contains a helpful little shell 
 
 ### Update
 
-Regulary run `craft selfupdate`so the tool will get the latest version from GitHub and update itself.
+Regulary run `craft selfupdate` so the tool will get the latest version from GitHub and update itself.
 
 ### Start
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ This will start the default action defined in your gulpfile. To run a specific t
 craft gulp build
 ```
 
+### Define webserver root directory
+Rename the `web` folder to `public`. This is the access point for our webserver.
+
 ### Finishline
 
 When everything has worked until this point you should be able to open [localhost:8080](http://localhost:8080) in


### PR DESCRIPTION
In order to access the Craft CMS website that is served by the docker container, the webroot has to be renamed from `web` to `public`. This info is added in this PR. :)

Feel free to adjust or add to the explanation. ;)