### PR TITLE
Change UID/GID of www-data on Linux systems

### DIFF
--- a/bin/craft
+++ b/bin/craft
@@ -145,7 +145,13 @@ function start {
       PHPVERSION=$DEFAULT_PHP
     fi
 
-    docker run --rm -d --name craft -p 8080:80 -v "${PWD}:/local" -e "PHPVERSION=$PHPVERSION" --link mysql:mysql --link redis:cache "$CRAFT_CONTAINER" > /dev/null
+    if [ `uname -s` == "Linux" ]; then
+        echo "You appear to be running Linux. Trying to fix permissions for mounted volumes inside container"
+        docker run --rm -d --name craft -p 8080:80 -v "${PWD}:/local" -e "CUSTOM_UID=`id -u`" -e "CUSTOM_GID=`id -g`" -e "PHPVERSION=$PHPVERSION" --link mysql:mysql --link redis:cache "$CRAFT_CONTAINER" > /dev/null
+    else
+        docker run --rm -d --name craft -p 8080:80 -v "${PWD}:/local" -e "PHPVERSION=$PHPVERSION" --link mysql:mysql --link redis:cache "$CRAFT_CONTAINER" > /dev/null
+    fi
+
     if [ $? == 0 ]; then
       log_success "Started Craft CMS environment in ${PWD}"
       log_info "Now create something awesome 🚀"

--- a/includes/usr/local/bin/run.sh
+++ b/includes/usr/local/bin/run.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ ! -z "$CUSTOM_UID" ] && [ ! -z "$CUSTOM_GID" ]; then
+    usermod -u $CUSTOM_UID www-data && groupmod -g $CUSTOM_GID www-data
+fi
+
 # Switch php version for the cli
 update-alternatives --set php /usr/bin/php"$PHPVERSION"
 


### PR DESCRIPTION
The document root gets mounted from the host into the container and
therefore has the same uid and gid of the user on the host. These IDs
are not available inside the container and PHP is running as www-data
and therefore not allowed to write to these directorys.

This problem has not accured before because this tool has only been used
on macOS where Docker is run inside an additional virtual machine which
does some magic to fix the permissions for mounted volumes.

The new script detects if the host is running Linux and then changes the
UID/GID of the www-data user inside the container to the values of the
original user on the host. Therefore the files under '/local' belong to
www-data and craft can write its files to this location.